### PR TITLE
Cmillar/donating endpoints

### DIFF
--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -92,7 +92,13 @@ static inline void endpoint_ptr_mset_epQueue_tail_state(endpoint_t *ep_ptr, word
 
 static inline void endpoint_ptr_set_epQueue_head_np(endpoint_t *ep_ptr, word_t epQueue_head)
 {
+#ifdef CONFIG_KERNEL_MCS
+    // Fastpath only used on donating endpoints
+    bool_t isDonating = ep_ptr->words[1] & true;
+    ep_ptr->words[1] = epQueue_head | isDonating;
+#else
     ep_ptr->words[1] = epQueue_head;
+#endif
 }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -180,6 +180,12 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
  */
 void refill_budget_check(ticks_t used);
 
+/* Charge `usage` to the current scheduling context (round-robin).
+ *
+ * @param usage the amount of time to charge.
+ */
+void refill_budget_check_round_robin(ticks_t usage);
+
 /*
  * This is called when a thread is eligible to start running: it
  * iterates through the refills queue and merges any

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -170,16 +170,13 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
 /* Update refills in an active sc without violating bandwidth constraints */
 void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, word_t new_max_refills);
 
-
 /* Charge `usage` to the current scheduling context.
- * This function should only be called only when charging `used` will deplete
- * the head refill, resulting in refill_sufficient failing.
  *
  * @param usage the amount of time to charge.
  * @param capacity the value returned by refill_capacity. At most call sites this
  * has already been calculated so pass the value in rather than calculating it again.
  */
-void refill_budget_check(ticks_t used, ticks_t capacity);
+void refill_budget_check(ticks_t used);
 
 /*
  * This is called when a thread is eligible to start running: it

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -182,14 +182,6 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
 void refill_budget_check(ticks_t used, ticks_t capacity);
 
 /*
- * Charge a the current scheduling context `used` amount from its
- * current refill. This will split the refill, leaving whatever is
- * left over at the head of the refill. This is only called when charging
- * `used` will not deplete the head refill.
- */
-void refill_split_check(ticks_t used);
-
-/*
  * This is called when a thread is eligible to start running: it
  * iterates through the refills queue and merges any
  * refills that overlap.

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -38,7 +38,9 @@
 /* To do an operation in the kernel, the thread must have
  * at least this much budget - see comment on refill_sufficient */
 #define MIN_BUDGET_US (2u * getKernelWcetUs() * CONFIG_KERNEL_WCET_SCALE)
+#define MIN_SC_BUDGET_US (2 * MIN_BUDGET_US)
 #define MIN_BUDGET    (2u * getKernelWcetTicks() * CONFIG_KERNEL_WCET_SCALE)
+#define MIN_SC_BUDGET (2 * MIN_BUDGET)
 
 /* Short hand for accessing refill queue items */
 #define REFILL_BUFFER(sc) ((refill_t *) (SC_REF(sc) + sizeof(sched_context_t)))

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -113,7 +113,7 @@ static inline void commitTime(void)
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += NODE_STATE(ksConsumed);
             } else {
-                refill_budget_check(NODE_STATE(ksConsumed), 0);
+                refill_budget_check(NODE_STATE(ksConsumed));
             }
             assert(refill_sufficient(NODE_STATE(ksCurSC), 0));
             assert(refill_ready(NODE_STATE(ksCurSC)));
@@ -192,7 +192,7 @@ static inline void updateRestartPC(tcb_t *tcb)
 void endTimeslice(bool_t can_timeout_fault);
 
 /* called when a thread has used up its head refill */
-void chargeBudget(ticks_t capacity, ticks_t consumed, bool_t canTimeoutFault, word_t core, bool_t isCurCPU);
+void chargeBudget(ticks_t consumed, bool_t canTimeoutFault, word_t core, bool_t isCurCPU);
 
 /* Update the kernels timestamp and stores in ksCurTime.
  * The difference between the previous kernel timestamp and the one just read
@@ -235,7 +235,7 @@ static inline bool_t checkBudget(void)
         return true;
     }
 
-    chargeBudget(capacity, NODE_STATE(ksConsumed), true, CURRENT_CPU_INDEX(), true);
+    chargeBudget(NODE_STATE(ksConsumed), true, CURRENT_CPU_INDEX(), true);
     return false;
 }
 

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -113,7 +113,7 @@ static inline void commitTime(void)
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += NODE_STATE(ksConsumed);
             } else {
-                refill_split_check(NODE_STATE(ksConsumed));
+                refill_budget_check(NODE_STATE(ksConsumed), 0);
             }
             assert(refill_sufficient(NODE_STATE(ksCurSC), 0));
             assert(refill_ready(NODE_STATE(ksCurSC)));

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -110,7 +110,6 @@ static inline void commitTime(void)
             if (isRoundRobin(NODE_STATE(ksCurSC))) {
                 /* for round robin threads, we can just update the
                  * single refill in the SC. */
-                NODE_STATE(ksCurSC)->scRefillHead = NODE_STATE(ksCurSC)->scRefillTail;
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
                 REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += NODE_STATE(ksConsumed);
             } else {

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -108,10 +108,7 @@ static inline void commitTime(void)
             assert(refill_ready(NODE_STATE(ksCurSC)));
 
             if (isRoundRobin(NODE_STATE(ksCurSC))) {
-                /* for round robin threads, we can just update the
-                 * single refill in the SC. */
-                REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
-                REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += NODE_STATE(ksConsumed);
+                refill_budget_check_round_robin(NODE_STATE(ksConsumed));
             } else {
                 refill_budget_check(NODE_STATE(ksConsumed));
             }

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -356,12 +356,12 @@ struct sched_context {
     /* thread that yielded to this scheduling context */
     tcb_t *scYieldFrom;
 
-    /* Amount of refills this sc tracks */
+    /* Maximum number of refills this sc can track */
     word_t scRefillMax;
     /* Index of the head of the refill circular buffer */
     word_t scRefillHead;
-    /* Index of the tail of the refill circular buffer */
-    word_t scRefillTail;
+    /* Number of refills in the refill buffer */
+    word_t scRefillCount;
 };
 
 struct reply {

--- a/include/object/structures_32.bf
+++ b/include/object/structures_32.bf
@@ -153,7 +153,8 @@ block endpoint {
     padding 64
 
     field_high epQueue_head 28
-    padding 4
+    padding 3
+    field isDonating 1
 
     field_high epQueue_tail 28
     padding 2

--- a/include/object/structures_64.bf
+++ b/include/object/structures_64.bf
@@ -208,7 +208,16 @@ block sched_control_cap {
 
 -- Endpoint: size = 16 bytes
 block endpoint {
-    field epQueue_head 64
+#if BF_CANONICAL_RANGE == 48
+    padding 16
+    field_high epQueue_head 47
+#elif BF_CANONICAL_RANGE == 39
+    padding 25
+    field_high epQueue_head 38
+#else
+#error "Unspecified canonical address range"
+#endif
+    field isDonating 1
 
 #if BF_CANONICAL_RANGE == 48
     padding 16

--- a/libsel4/include/sel4/objecttype.h
+++ b/libsel4/include/sel4/objecttype.h
@@ -17,6 +17,9 @@ typedef enum api_object {
     seL4_UntypedObject,
     seL4_TCBObject,
     seL4_EndpointObject,
+#ifdef CONFIG_KERNEL_MCS
+    seL4_DonatingEndpointObject,
+#endif
     seL4_NotificationObject,
     seL4_CapTableObject,
 #ifdef CONFIG_KERNEL_MCS

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -533,8 +533,7 @@ static inline void mcsIRQ(irq_t irq)
         checkBudget();
     } else if (NODE_STATE(ksCurSC)->scRefillMax) {
         /* otherwise, if the thread is not schedulable, the SC could be valid - charge it if so */
-        ticks_t capacity = refill_capacity(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed));
-        chargeBudget(capacity, NODE_STATE(ksConsumed), false, CURRENT_CPU_INDEX(), true);
+        chargeBudget(NODE_STATE(ksConsumed), false, CURRENT_CPU_INDEX(), true);
     }
 
 }
@@ -549,7 +548,7 @@ static void handleYield(void)
 #ifdef CONFIG_KERNEL_MCS
     /* Yield the current remaining budget */
     ticks_t consumed = NODE_STATE(ksCurSC)->scConsumed;
-    chargeBudget(0, REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount, false, CURRENT_CPU_INDEX(), true);
+    chargeBudget(REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount, false, CURRENT_CPU_INDEX(), true);
     NODE_STATE(ksCurSC)->scConsumed = consumed;
 #else
     tcbSchedDequeue(NODE_STATE(ksCurThread));

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -30,10 +30,6 @@
  * [x][t][][][][h][x][x]
  *
  * The queue has a minimum size of 1, so it is possible that h == t.
- *
- * The queue is implemented as head + tail rather than head + size as
- * we cannot use the mod operator on all architectures without accessing
- * the fpu or implementing divide.
  */
 
 /* return the index of the next item in the refill queue */
@@ -53,14 +49,14 @@ UNUSED static inline void print_index(sched_context_t *sc, word_t index)
 
 UNUSED static inline void refill_print(sched_context_t *sc)
 {
-    printf("Head %lu tail %lu\n", sc->scRefillHead, sc->scRefillTail);
-    word_t current = sc->scRefillHead;
-    /* always print the head */
-    print_index(sc, current);
+    printf("Head %lu length %lu\n", sc->scRefillHead, sc->scRefillCount);
 
-    while (current != sc->scRefillTail) {
-        current = refill_next(sc, current);
+    word_t current = sc->scRefillHead;
+    word_t seen = 0;
+    while (seen != sc->scRefillCount) {
         print_index(sc, current);
+        current = refill_next(sc, current);
+        seen += 1;
     }
 
 }
@@ -74,14 +70,16 @@ static UNUSED bool_t refill_ordered_disjoint(sched_context_t *sc)
 {
     word_t current = sc->scRefillHead;
     word_t next = refill_next(sc, sc->scRefillHead);
+    word_t seen = 1;
 
-    while (current != sc->scRefillTail) {
+    while (seen < sc->scRefillCount) {
         if (!(REFILL_INDEX(sc, current).rTime + REFILL_INDEX(sc, current).rAmount <= REFILL_INDEX(sc, next).rTime)) {
             refill_print(sc);
             return false;
         }
         current = next;
         next = refill_next(sc, current);
+        seen += 1;
     }
 
     return true;
@@ -91,16 +89,15 @@ static UNUSED bool_t refill_ordered_disjoint(sched_context_t *sc)
 static UNUSED bool_t refill_at_least_min_budget(sched_context_t *sc)
 {
     word_t current = sc->scRefillHead;
+    word_t seen = 0;
 
-    while (true) {
+    while (seen < sc->scRefillCount) {
         if (!(REFILL_INDEX(sc, current).rAmount >= MIN_BUDGET)) {
             refill_print(sc);
             return false;
         }
-        if (current == sc->scRefillTail) {
-            break;
-        }
         current = refill_next(sc, current);
+        seen += 1;
     }
 
     return true;
@@ -157,12 +154,14 @@ static UNUSED void sched_invariants(sched_context_t *sc)
 /* compute the sum of a refill queue */
 static UNUSED ticks_t refill_sum(sched_context_t *sc)
 {
-    ticks_t sum = REFILL_HEAD(sc).rAmount;
+    ticks_t sum = 0;
     word_t current = sc->scRefillHead;
+    word_t seen = 0;
 
-    while (current != sc->scRefillTail) {
-        current = refill_next(sc, current);
+    while (seen < sc->scRefillCount) {
         sum += REFILL_INDEX(sc, current).rAmount;
+        current = refill_next(sc, current);
+        seen += 1;
     }
 
     return sum;
@@ -172,11 +171,12 @@ static UNUSED ticks_t refill_sum(sched_context_t *sc)
 static inline refill_t refill_pop_head(sched_context_t *sc)
 {
     /* queues cannot be smaller than 1 */
-    assert(!refill_single(sc));
+    assert(refill_size(sc) > 0);
 
     UNUSED word_t prev_size = refill_size(sc);
     refill_t refill = REFILL_HEAD(sc);
     sc->scRefillHead = refill_next(sc, sc->scRefillHead);
+    sc->scRefillCount -= 1;
 
     /* sanity */
     assert(prev_size == (refill_size(sc) + 1));
@@ -190,12 +190,8 @@ static inline void refill_add_tail(sched_context_t *sc, refill_t refill)
     /* cannot add beyond queue size */
     assert(refill_size(sc) < sc->scRefillMax);
 
-    word_t new_tail = refill_next(sc, sc->scRefillTail);
-    sc->scRefillTail = new_tail;
+    sc->scRefillCount += 1;
     REFILL_TAIL(sc) = refill;
-
-    /* sanity */
-    assert(new_tail < sc->scRefillMax);
 }
 
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period)
@@ -203,7 +199,7 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
     sc->scPeriod = period;
     sc->scBudget = budget;
     sc->scRefillHead = 0;
-    sc->scRefillTail = 0;
+    sc->scRefillCount = 1;
     sc->scRefillMax = max_refills;
     assert(budget > MIN_BUDGET);
     /* full budget available */
@@ -215,18 +211,25 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
 
 static inline void schedule_used(sched_context_t *sc, refill_t new)
 {
-    /* The refills being disjoint allows for them to be merged with the
-     * resulting refill being earlier. */
-    assert(new.rTime >= REFILL_TAIL(sc).rTime + REFILL_TAIL(sc).rAmount);
-
-    /* schedule the used amount */
-    if (new.rAmount < MIN_BUDGET || refill_full(sc)) {
-        /* Merge with existing tail */
-        REFILL_TAIL(sc).rTime = new.rTime - REFILL_TAIL(sc).rAmount;
-        REFILL_TAIL(sc).rAmount += new.rAmount;
-    } else {
+    if (refill_empty(sc)) {
+        assert(new.rAmount >= MIN_BUDGET);
         refill_add_tail(sc, new);
+    } else {
+        /* The refills being disjoint allows for them to be merged with
+         * the resulting refill being earlier. */
+        assert(new.rTime >= REFILL_TAIL(sc).rTime + REFILL_TAIL(sc).rAmount);
+
+        /* schedule the used amount */
+        if (new.rAmount < MIN_BUDGET || refill_full(sc)) {
+            /* Merge with existing tail */
+            REFILL_TAIL(sc).rTime = new.rTime - REFILL_TAIL(sc).rAmount;
+            REFILL_TAIL(sc).rAmount += new.rAmount;
+        } else {
+            refill_add_tail(sc, new);
+        }
     }
+
+    assert(!refill_empty(sc));
 }
 
 void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, word_t new_max_refills)
@@ -243,7 +246,7 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
     REFILL_INDEX(sc, 0) = REFILL_HEAD(sc);
     sc->scRefillHead = 0;
     /* truncate refill list to size 1 */
-    sc->scRefillTail = sc->scRefillHead;
+    sc->scRefillCount = 1;
     /* update max refills */
     sc->scRefillMax = new_max_refills;
     /* update period */

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -32,6 +32,13 @@
  * The queue has a minimum size of 1, so it is possible that h == t.
  */
 
+/*
+ * Remove `used` from the head refill. If the resulting refill ends up
+ * smaller than the MIN_REFILL, remove the head refill and return the
+ * amount left over (or 0 otherwise).
+ */
+ticks_t refill_split_check(ticks_t used);
+
 /* return the index of the next item in the refill queue */
 static inline word_t refill_next(sched_context_t *sc, word_t index)
 {
@@ -129,6 +136,7 @@ static UNUSED bool_t refill_all_within_period(sched_context_t *sc)
 
 static UNUSED void sched_invariants(sched_context_t *sc)
 {
+    assert(!refill_empty(sc));
     assert(refill_ordered_disjoint(sc));
     assert(refill_at_least_min_budget(sc));
     assert(refill_all_within_period(sc));
@@ -275,45 +283,48 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
 
 void refill_budget_check(ticks_t usage, ticks_t capacity)
 {
+    /* After refill budget check there should be a single refill at the
+     * tail of the refill queue that = */
     sched_context_t *sc = NODE_STATE(ksCurSC);
     /* this function should only be called when the sc is out of budget */
     assert(capacity < MIN_BUDGET || refill_full(sc));
     assert(!isRoundRobin(sc));
     REFILL_SANITY_START(sc);
 
-    if (usage > sc->scBudget) {
-        /* budget overrun */
-        ticks_t overrun = usage - sc->scBudget;
+    /* After refill_unblock_check, which is called on exit from the
+     * kernel, the head refill will have started at the last kernel
+     * entry. As such, the new refill from the used will begin one
+     * period after that entry. */
 
-        /* set the only refill to be now + period + excess used */
-        sc->scRefillTail = sc->scRefillHead;
-        REFILL_HEAD(sc).rAmount = sc->scBudget;
-        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime) + sc->scPeriod + overrun;
-    } else {
-        if (capacity == 0) {
-            while (REFILL_HEAD(sc).rAmount <= usage && refill_ready(sc)) {
-                /* exhaust and schedule replenishment */
-                usage -= REFILL_HEAD(sc).rAmount;
-                if (refill_single(sc)) {
-                    /* update in place */
-                    REFILL_HEAD(sc).rTime += sc->scPeriod;
-                } else {
-                    refill_t old_head = refill_pop_head(sc);
-                    old_head.rTime = old_head.rTime + sc->scPeriod;
-                    schedule_used(sc, old_head);
-                }
-            }
-        }
+    ticks_t last_entry = REFILL_HEAD(sc).rTime;
 
-        if (usage > 0 && !refill_ready(sc)) {
-            /* set the only refill to be now + period + excess used */
-            sc->scRefillTail = sc->scRefillHead;
-            REFILL_HEAD(sc).rAmount = sc->scBudget;
-            REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime) + sc->scPeriod + usage;
-        } else if (usage > 0) {
-            refill_split_check(usage);
+    refill_t used = (refill_t) {
+        .rAmount = usage,
+        .rTime = last_entry + sc->scPeriod,
+    };
+
+    if (capacity == 0) {
+        while (REFILL_HEAD(sc).rAmount <= usage && refill_ready(sc)) {
+            refill_t old_head = refill_pop_head(sc);
+            usage -= old_head.rAmount;
         }
     }
+
+    if (unlikely(usage > 0 && !refill_ready(sc))) {
+        /* Budget overrun so empty the refill list entirely and schedule
+         * a single refill of the full budget far enough in the future
+         * to restore the bandwidth limitation. */
+        sc->scRefillCount = 0;
+        used.rTime += usage;
+        used.rAmount = sc->scBudget;
+    } else if (usage > 0) {
+        ticks_t remnant = refill_split_check(usage);
+        used.rTime -= remnant;
+        used.rAmount += remnant;
+    }
+
+    /* Schedule all of the used time as a single refill. */
+    schedule_used(used);
 
     REFILL_SANITY_END(sc);
 }
@@ -335,40 +346,21 @@ void refill_split_check(ticks_t usage)
     /* first deal with the remaining budget of the current replenishment */
     ticks_t remnant = REFILL_HEAD(sc).rAmount - usage;
 
-    /* set up a new replenishment structure */
-    refill_t new = (refill_t) {
-        .rAmount = usage, .rTime = REFILL_HEAD(sc).rTime + sc->scPeriod
-    };
-
     if (remnant < MIN_BUDGET) {
-        /* merge remnant with next replenishment it's too small */
-        if (refill_single(sc)) {
-            /* update inplace */
-            new.rAmount += remnant;
-            new.rTime -= remnant;
-            REFILL_HEAD(sc) = new;
-        } else {
-            refill_pop_head(sc);
-            REFILL_HEAD(sc).rAmount += remnant;
-            REFILL_HEAD(sc).rTime -= remnant;
-            schedule_used(sc, new);
-        }
+        refill_pop_head(sc);
     } else {
-        /* leave remnant as reduced replenishment */
-        assert(remnant >= MIN_BUDGET);
-        /* split the head refill  */
-        REFILL_HEAD(sc).rAmount = remnant;
-        /* Move the remaining head to account for the consumed time */
-        REFILL_HEAD(sc).rTime += usage;
-        schedule_used(sc, new);
+        REFILL_HEAD.rAmount = remnant;
+        REFILL_HEAD.rTime += usage;
+        remnant = 0;
     }
 
     REFILL_SANITY_END(sc);
+
+    return remnant;
 }
 
 void refill_unblock_check(sched_context_t *sc)
 {
-
     if (isRoundRobin(sc)) {
         /* nothing to do */
         return;
@@ -381,7 +373,7 @@ void refill_unblock_check(sched_context_t *sc)
         NODE_STATE(ksReprogram) = true;
 
         /* merge available replenishments */
-        while (!refill_single(sc)) {
+        while (refill_size(sc) > 1) {
             ticks_t amount = REFILL_HEAD(sc).rAmount;
             if (REFILL_INDEX(sc, refill_next(sc, sc->scRefillHead)).rTime <= NODE_STATE(ksCurTime) + amount) {
                 refill_pop_head(sc);

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -136,6 +136,11 @@ static UNUSED void sched_invariants(sched_context_t *sc)
     assert(refill_at_least_min_budget(sc));
     assert(refill_all_within_period(sc));
     assert(refill_sum_to_budget(sc));
+    if (isRoundRobin(sc)) {
+        assert(sc->scRefillCount == 2 || (sc->scRefillCount == 1 && REFILL_HEAD(sc).rAmount == sc->scBudget));
+        assert(refill_ready(sc));
+        assert(refill_sufficient(sc, 0));
+    }
 }
 
 #define REFILL_SANITY_START(sc) ticks_t _sum = refill_sum(sc); sched_invariants(sc);
@@ -283,6 +288,46 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
     REFILL_SANITY_CHECK(sc, new_budget);
 }
 
+void refill_budget_check_round_robin(ticks_t usage)
+{
+    sched_context_t *sc = NODE_STATE(ksCurSC);
+    assert(isRoundRobin(sc));
+    REFILL_SANITY_START(sc);
+
+    if (usage < MIN_BUDGET && sc->scRefillCount == 1) {
+        /* If a new refill is created it will be at least MIN_BUDGET. */
+        usage = MIN_BUDGET;
+    }
+
+    if (REFILL_HEAD(sc).rAmount >= usage + MIN_BUDGET) {
+        /* The amount left in the head must be at least MIN_BUDGET. */
+        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime);
+        REFILL_HEAD(sc).rAmount -= usage;
+        /* Consume only a portion of the head refill */
+        if (sc->scRefillCount == 1) {
+            refill_t new = {
+                .rTime = REFILL_HEAD(sc).rTime + REFILL_HEAD(sc).rAmount,
+                .rAmount = usage,
+            };
+            refill_add_tail(sc, new);
+            assert(refill_ordered_disjoint(sc));
+        } else {
+            assert(sc->scRefillCount == 2);
+            REFILL_TAIL(sc).rTime = REFILL_HEAD(sc).rTime + REFILL_HEAD(sc).rAmount;
+            REFILL_TAIL(sc).rAmount += usage;
+        }
+    } else {
+        /* Reset to a single refill */
+        sc->scRefillCount = 1;
+        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime);
+        REFILL_HEAD(sc).rAmount = sc->scBudget;
+    }
+
+    assert(REFILL_HEAD(sc).rTime == NODE_STATE(ksCurTime));
+    REFILL_SANITY_END(sc);
+    return;
+}
+
 void refill_budget_check(ticks_t usage)
 {
     /* After refill budget check there should be a single refill at the
@@ -346,7 +391,11 @@ void refill_budget_check(ticks_t usage)
 void refill_unblock_check(sched_context_t *sc)
 {
     if (isRoundRobin(sc)) {
-        /* nothing to do */
+        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime) + getKernelWcetTicks();
+        if (sc->scRefillCount > 1) {
+            REFILL_TAIL(sc).rTime = REFILL_HEAD(sc).rTime + REFILL_HEAD(sc).rAmount;
+        }
+        REFILL_SANITY_CHECK(sc, sc->scBudget);
         return;
     }
 

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -344,21 +344,24 @@ void refill_unblock_check(sched_context_t *sc)
     /* advance earliest activation time to now */
     REFILL_SANITY_START(sc);
     if (refill_ready(sc)) {
-        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime);
         NODE_STATE(ksReprogram) = true;
+
+        REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime) + getKernelWcetTicks();
 
         /* merge available replenishments */
         while (refill_size(sc) > 1) {
             ticks_t amount = REFILL_HEAD(sc).rAmount;
-            if (REFILL_INDEX(sc, refill_next(sc, sc->scRefillHead)).rTime <= NODE_STATE(ksCurTime) + amount) {
+            ticks_t tail = REFILL_HEAD(sc).rTime + amount;
+            if (REFILL_INDEX(sc, refill_next(sc, sc->scRefillHead)).rTime <= tail) {
                 refill_pop_head(sc);
                 REFILL_HEAD(sc).rAmount += amount;
-                REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime);
+                REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime) + getKernelWcetTicks();
             } else {
                 break;
             }
         }
 
+        assert(refill_ready(sc));
         assert(refill_sufficient(sc, 0));
     }
     REFILL_SANITY_END(sc);

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -32,13 +32,6 @@
  * The queue has a minimum size of 1, so it is possible that h == t.
  */
 
-/*
- * Remove `used` from the head refill. If the resulting refill ends up
- * smaller than the MIN_REFILL, remove the head refill and return the
- * amount left over (or 0 otherwise).
- */
-ticks_t refill_split_check(ticks_t used);
-
 /* return the index of the next item in the refill queue */
 static inline word_t refill_next(sched_context_t *sc, word_t index)
 {
@@ -311,44 +304,34 @@ void refill_budget_check(ticks_t usage)
         sc->scRefillCount = 0;
         used.rTime += usage;
         used.rAmount = sc->scBudget;
-    } else if (usage == REFILL_HEAD(sc).rAmount) {
+    } else if (unlikely(usage == REFILL_HEAD(sc).rAmount)) {
         refill_pop_head(sc);
     } else {
-        ticks_t remnant = refill_split_check(usage);
-        used.rTime -= remnant;
-        used.rAmount += remnant;
+        ticks_t remnant = REFILL_HEAD(sc).rAmount - usage;
+
+        if (remnant >= MIN_BUDGET) {
+            /* Leave the head refill with all that was leftover */
+            REFILL_HEAD(sc).rAmount = remnant;
+            REFILL_HEAD(sc).rTime += usage;
+        } else {
+            /* Merge the remaining time to the start of the following
+             * refill */
+            refill_pop_head(sc);
+            if (refill_empty(sc)) {
+                /* Used will become the new head */
+                used.rTime -= remnant;
+                used.rAmount += remnant;
+            } else {
+                REFILL_HEAD(sc).rTime -= remnant;
+                REFILL_HEAD(sc).rAmount += remnant;
+            }
+        }
     }
 
     /* Schedule all of the used time as a single refill. */
     schedule_used(sc, used);
 
     REFILL_SANITY_END(sc);
-}
-
-ticks_t refill_split_check(ticks_t usage)
-{
-    sched_context_t *sc = NODE_STATE(ksCurSC);
-    /* invalid to call this on a NULL sc */
-    assert(sc != NULL);
-    assert(refill_ready(sc));
-    /* something is seriously wrong if this is called and no
-     * time has been used */
-    assert(usage > 0);
-    assert(usage < REFILL_HEAD(sc).rAmount);
-    assert(!isRoundRobin(sc));
-
-    /* first deal with the remaining budget of the current replenishment */
-    ticks_t remnant = REFILL_HEAD(sc).rAmount - usage;
-
-    if (remnant < MIN_BUDGET) {
-        refill_pop_head(sc);
-    } else {
-        REFILL_HEAD(sc).rAmount = remnant;
-        REFILL_HEAD(sc).rTime += usage;
-        remnant = 0;
-    }
-
-    return remnant;
 }
 
 void refill_unblock_check(sched_context_t *sc)

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -50,6 +50,7 @@ UNUSED static inline void print_index(sched_context_t *sc, word_t index)
 UNUSED static inline void refill_print(sched_context_t *sc)
 {
     printf("Head %lu length %lu\n", sc->scRefillHead, sc->scRefillCount);
+    printf("Budget %lu Period %lu\n", (long)sc->scBudget, (long)sc->scPeriod);
 
     word_t current = sc->scRefillHead;
     word_t seen = 0;

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -130,6 +130,7 @@ static UNUSED bool_t refill_all_within_period(sched_context_t *sc)
 static UNUSED void sched_invariants(sched_context_t *sc)
 {
     assert(!refill_empty(sc));
+    assert(sc->scBudget >= MIN_SC_BUDGET);
     assert(refill_ordered_disjoint(sc));
     assert(refill_at_least_min_budget(sc));
     assert(refill_all_within_period(sc));
@@ -221,7 +222,14 @@ static inline void schedule_used(sched_context_t *sc, refill_t new)
         assert(new.rTime >= REFILL_TAIL(sc).rTime + REFILL_TAIL(sc).rAmount);
 
         /* schedule the used amount */
-        if (new.rAmount < MIN_BUDGET || refill_full(sc)) {
+        if (new.rAmount < MIN_BUDGET && !refill_full(sc) && REFILL_TAIL(sc).rAmount + new.rAmount >= 2 * MIN_BUDGET) {
+            /* Split tail into two parts of at least MIN_BUDGET */
+            ticks_t remainder = MIN_BUDGET - new.rAmount;
+            new.rAmount += remainder;
+            new.rTime -= remainder;
+            REFILL_TAIL(sc).rAmount -= remainder;
+            refill_add_tail(sc, new);
+        } else if (new.rAmount < MIN_BUDGET || refill_full(sc)) {
             /* Merge with existing tail */
             REFILL_TAIL(sc).rTime = new.rTime - REFILL_TAIL(sc).rAmount;
             REFILL_TAIL(sc).rAmount += new.rAmount;

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -281,13 +281,11 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
     REFILL_SANITY_CHECK(sc, new_budget);
 }
 
-void refill_budget_check(ticks_t usage, ticks_t capacity)
+void refill_budget_check(ticks_t usage)
 {
     /* After refill budget check there should be a single refill at the
      * tail of the refill queue that = */
     sched_context_t *sc = NODE_STATE(ksCurSC);
-    /* this function should only be called when the sc is out of budget */
-    assert(capacity < MIN_BUDGET || refill_full(sc));
     assert(!isRoundRobin(sc));
     REFILL_SANITY_START(sc);
 
@@ -303,33 +301,31 @@ void refill_budget_check(ticks_t usage, ticks_t capacity)
         .rTime = last_entry + sc->scPeriod,
     };
 
-    if (capacity == 0) {
-        while (REFILL_HEAD(sc).rAmount <= usage && refill_ready(sc)) {
-            refill_t old_head = refill_pop_head(sc);
-            usage -= old_head.rAmount;
-        }
-    }
+    /* After refill_unblock_check, using more than the head refill
+     * indicates a bandwidth overrun. */
 
-    if (unlikely(usage > 0 && !refill_ready(sc))) {
+    if (unlikely(!refill_ready(sc) || REFILL_HEAD(sc).rAmount < usage)) {
         /* Budget overrun so empty the refill list entirely and schedule
          * a single refill of the full budget far enough in the future
          * to restore the bandwidth limitation. */
         sc->scRefillCount = 0;
         used.rTime += usage;
         used.rAmount = sc->scBudget;
-    } else if (usage > 0) {
+    } else if (usage == REFILL_HEAD(sc).rAmount) {
+        refill_pop_head(sc);
+    } else {
         ticks_t remnant = refill_split_check(usage);
         used.rTime -= remnant;
         used.rAmount += remnant;
     }
 
     /* Schedule all of the used time as a single refill. */
-    schedule_used(used);
+    schedule_used(sc, used);
 
     REFILL_SANITY_END(sc);
 }
 
-void refill_split_check(ticks_t usage)
+ticks_t refill_split_check(ticks_t usage)
 {
     sched_context_t *sc = NODE_STATE(ksCurSC);
     /* invalid to call this on a NULL sc */
@@ -341,20 +337,16 @@ void refill_split_check(ticks_t usage)
     assert(usage < REFILL_HEAD(sc).rAmount);
     assert(!isRoundRobin(sc));
 
-    REFILL_SANITY_START(sc);
-
     /* first deal with the remaining budget of the current replenishment */
     ticks_t remnant = REFILL_HEAD(sc).rAmount - usage;
 
     if (remnant < MIN_BUDGET) {
         refill_pop_head(sc);
     } else {
-        REFILL_HEAD.rAmount = remnant;
-        REFILL_HEAD.rTime += usage;
+        REFILL_HEAD(sc).rAmount = remnant;
+        REFILL_HEAD(sc).rTime += usage;
         remnant = 0;
     }
-
-    REFILL_SANITY_END(sc);
 
     return remnant;
 }

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -595,7 +595,7 @@ void setNextInterrupt(void)
     setDeadline(next_interrupt - getTimerPrecision());
 }
 
-void chargeBudget(ticks_t capacity, ticks_t consumed, bool_t canTimeoutFault, word_t core, bool_t isCurCPU)
+void chargeBudget(ticks_t consumed, bool_t canTimeoutFault, word_t core, bool_t isCurCPU)
 {
 
     if (isRoundRobin(NODE_STATE_ON_CORE(ksCurSC, core))) {
@@ -604,7 +604,7 @@ void chargeBudget(ticks_t capacity, ticks_t consumed, bool_t canTimeoutFault, wo
         REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
         REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += consumed;
     } else {
-        refill_budget_check(consumed, capacity);
+        refill_budget_check(consumed);
     }
 
     assert(REFILL_HEAD(NODE_STATE_ON_CORE(ksCurSC, core)).rAmount >= MIN_BUDGET);

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -599,10 +599,7 @@ void chargeBudget(ticks_t consumed, bool_t canTimeoutFault, word_t core, bool_t 
 {
 
     if (isRoundRobin(NODE_STATE_ON_CORE(ksCurSC, core))) {
-        /* for round robin threads, we can just update the
-         * single refill in the SC. */
-        REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
-        REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += consumed;
+        refill_budget_check_round_robin(consumed);
     } else {
         refill_budget_check(consumed);
     }

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -601,7 +601,6 @@ void chargeBudget(ticks_t capacity, ticks_t consumed, bool_t canTimeoutFault, wo
     if (isRoundRobin(NODE_STATE_ON_CORE(ksCurSC, core))) {
         /* for round robin threads, we can just update the
          * single refill in the SC. */
-        NODE_STATE(ksCurSC)->scRefillHead = NODE_STATE(ksCurSC)->scRefillTail;
         REFILL_HEAD(NODE_STATE(ksCurSC)).rAmount = NODE_STATE(ksCurSC)->scBudget;
         REFILL_HEAD(NODE_STATE(ksCurSC)).rTime += consumed;
     } else {

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -244,7 +244,7 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
             if (do_call ||
                 seL4_Fault_get_seL4_FaultType(sender->tcbFault) != seL4_Fault_NullFault) {
                 if ((canGrant || canGrantReply) && replyPtr != NULL) {
-                    reply_push(sender, thread, replyPtr, sender->tcbSchedContext != NULL);
+                    reply_push(sender, thread, replyPtr, endpoint_ptr_get_isDonating(epptr));
                 } else {
                     setThreadState(sender, ThreadState_Inactive);
                 }

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -43,6 +43,9 @@ word_t getObjectSize(word_t t, word_t userObjSize)
         case seL4_TCBObject:
             return seL4_TCBBits;
         case seL4_EndpointObject:
+#ifdef CONFIG_KERNEL_MCS
+        case seL4_DonatingEndpointObject:
+#endif
             return seL4_EndpointBits;
         case seL4_NotificationObject:
             return seL4_NotificationBits;
@@ -548,6 +551,15 @@ cap_t createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceM
           (Ptr (ptr_val \<acute>regionBase) :: endpoint_C ptr))" */
         return cap_endpoint_cap_new(0, true, true, true, true,
                                     EP_REF(regionBase));
+
+#ifdef CONFIG_KERNEL_MCS
+    case seL4_DonatingEndpointObject:
+        endpoint_ptr_set_isDonating(EP_PTR(regionBase), 1);
+        /** AUXUPD: "(True, ptr_retyp
+          (Ptr (ptr_val \<acute>regionBase) :: endpoint_C ptr))" */
+        return cap_endpoint_cap_new(0, true, true, true, true,
+                                    EP_REF(regionBase));
+#endif
 
     case seL4_NotificationObject:
         /** AUXUPD: "(True, ptr_retyp

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -307,6 +307,15 @@ void schedContext_unbindTCB(sched_context_t *sc, tcb_t *tcb)
     tcbSchedDequeue(sc->scTcb);
     tcbReleaseRemove(sc->scTcb);
 
+    thread_state_t state = sc->scTcb->tcbState;
+    if (thread_state_get_tsType(state) == ThreadState_BlockedOnSend) {
+        /* Remove thread without SC from donating endpoint */
+        endpoint_t *epptr = EP_PTR(thread_state_get_blockingObject(state));
+        if (endpoint_ptr_get_isDonating(epptr)) {
+            cancelIPC(sc->scTcb);
+        }
+    }
+
     sc->scTcb->tcbSchedContext = NULL;
     sc->scTcb = NULL;
 }

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -105,18 +105,18 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > getMaxUsToTicks() || budget < MIN_BUDGET) {
+    if (budget_us > getMaxUsToTicks() || budget < MIN_SC_BUDGET) {
         userError("SchedControl_Configure: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
-        current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
+        current_syscall_error.rangeErrorMin = MIN_SC_BUDGET_US;
         current_syscall_error.rangeErrorMax = getMaxUsToTicks();
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (period_us > getMaxUsToTicks() || period < MIN_BUDGET) {
+    if (period_us > getMaxUsToTicks() || period < MIN_SC_BUDGET) {
         userError("SchedControl_Configure: period out of range.");
         current_syscall_error.type = seL4_RangeError;
-        current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
+        current_syscall_error.rangeErrorMin = MIN_SC_BUDGET_US;
         current_syscall_error.rangeErrorMax = getMaxUsToTicks();
         return EXCEPTION_SYSCALL_ERROR;
     }

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -91,7 +91,9 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     time_t budget_us = mode_parseTimeArg(0, buffer);
+    ticks_t budget = usToTicks(budget_us);
     time_t period_us = mode_parseTimeArg(TIME_ARG_SIZE, buffer);
+    ticks_t period = usToTicks(period_us);
     word_t extra_refills = getSyscallArg(TIME_ARG_SIZE * 2, buffer);
     word_t badge = getSyscallArg(TIME_ARG_SIZE * 2 + 1, buffer);
 
@@ -103,7 +105,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > getMaxUsToTicks() || budget_us < MIN_BUDGET_US) {
+    if (budget_us > getMaxUsToTicks() || budget < MIN_BUDGET) {
         userError("SchedControl_Configure: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -111,7 +113,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (period_us > getMaxUsToTicks() || period_us < MIN_BUDGET_US) {
+    if (period_us > getMaxUsToTicks() || period < MIN_BUDGET) {
         userError("SchedControl_Configure: period out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -119,7 +121,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > period_us) {
+    if (budget > period) {
         userError("SchedControl_Configure: budget must be <= period");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -140,8 +142,8 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
     return invokeSchedControl_Configure(SC_PTR(cap_sched_context_cap_get_capSCPtr(targetCap)),
                                         cap_sched_control_cap_get_core(cap),
-                                        usToTicks(budget_us),
-                                        usToTicks(period_us),
+                                        budget,
+                                        period,
                                         extra_refills + MIN_REFILLS,
                                         badge);
 }

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -64,7 +64,8 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
     }
 #endif /* ENABLE_SMP_SUPPORT */
 
-    if (target->scTcb && target->scRefillMax > 0) {
+    assert(target->scRefillMax > 0);
+    if (target->scTcb) {
         schedContext_resume(target);
         if (target->scTcb == NODE_STATE(ksCurThread)) {
             rescheduleRequired();

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -39,10 +39,7 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
                 }
 #ifdef ENABLE_SMP_SUPPORT
             } else {
-                /* if its a remote core, manually charge the budget */
-                ticks_t capacity = refill_capacity(target, NODE_STATE_ON_CORE(ksConsumed, target->scCore));
-
-                chargeBudget(capacity, NODE_STATE_ON_CORE(ksConsumed, target->scCore), false, target->scCore, false);
+                chargeBudget(NODE_STATE_ON_CORE(ksConsumed, target->scCore), false, target->scCore, false);
                 doReschedule(target->scCore);
             }
 #endif /* ENABLE_SMP_SUPPORT */

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -34,9 +34,11 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
 #ifdef ENABLE_SMP_SUPPORT
             if (target->scCore == getCurrentCPUIndex()) {
 #endif /* ENABLE_SMP_SUPPORT */
-                if (checkBudget()) {
-                    commitTime();
-                }
+                /* This could potentially mutate state but if it returns
+                 * true no state was modified, thus removing it should
+                 * be the same. */
+                assert(checkBudget());
+                commitTime();
 #ifdef ENABLE_SMP_SUPPORT
             } else {
                 chargeBudget(NODE_STATE_ON_CORE(ksConsumed, target->scCore), false, target->scCore, false);


### PR DESCRIPTION
Untyped memory can be retyped into a `seL4_DonatingEndpointObject` which is the same as a `seL4_EndpointObject` but with the guarantee that all blocked senders can donate their scheduling context.

When a donating endpoint is invoked for a send operation the caller must either be willing to donate its SC to the receiver or not block.

To maintain behaviour common with the existing interface, blocking calls that don't donate will lead to the sender being deactivated (as thought the IPC is blocked indefinitely) and non-blocking calls return immediately (as though no receiver was ready to receive an IPC).

A receiver must not be allowed to take a scheduling context from a thread blocked on a non-donating endpoint. Any receiver that attempts to accept donation from a non-donating endpoint is made inactive.