### PR TITLE
mcs: refill_unblock_check on unblock operations

### DIFF
--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -95,6 +95,12 @@ void restart(tcb_t *target)
         cancelIPC(target);
 #ifdef CONFIG_KERNEL_MCS
         setThreadState(target, ThreadState_Restart);
+        if (target->tcbSchedContext != NULL) {
+            assert(target->tcbSchedContext != NODE_STATE(ksCurSC));
+            // Target is now 'active' so we move all refills to begin
+            // after being blocked
+            refill_unblock_check(target->tcbSchedContext);
+        }
         schedContext_resume(target->tcbSchedContext);
         if (isSchedulable(target)) {
             possibleSwitchTo(target);
@@ -141,6 +147,10 @@ void doReplyTransfer(tcb_t *sender, tcb_t *receiver, cte_t *slot, bool_t grant)
     reply_remove(reply);
     assert(thread_state_get_replyObject(receiver->tcbState) == REPLY_REF(0));
     assert(reply->replyTCB == NULL);
+
+    if (receiver->tcbSchedContext && receiver->tcbSchedContext != NODE_STATE(ksCurSC)) {
+        refill_unblock_check(receiver->tcbSchedContext);
+    }
 #else
     assert(thread_state_get_tsType(receiver->tcbState) ==
            ThreadState_BlockedOnReply);
@@ -320,8 +330,6 @@ static void switchSchedContext(void)
 {
     if (unlikely(NODE_STATE(ksCurSC) != NODE_STATE(ksCurThread)->tcbSchedContext) && NODE_STATE(ksCurSC)->scRefillMax) {
         NODE_STATE(ksReprogram) = true;
-        refill_unblock_check(NODE_STATE(ksCurThread->tcbSchedContext));
-
         assert(refill_ready(NODE_STATE(ksCurThread->tcbSchedContext)));
         assert(refill_sufficient(NODE_STATE(ksCurThread->tcbSchedContext), 0));
     }

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -145,6 +145,15 @@ void sendSignal(notification_t *ntfnPtr, word_t badge)
             notification_ptr_set_state(ntfnPtr, NtfnState_Idle);
         }
 
+#ifdef CONFIG_KERNEL_MCS
+        if (dest->tcbSchedContext != NULL) {
+            assert(dest->tcbSchedContext != NODE_STATE(ksCurSC));
+            // Target is now 'active' so we move all refills to begin
+            // after being blocked
+            refill_unblock_check(dest->tcbSchedContext);
+        }
+#endif
+
         setThreadState(dest, ThreadState_Running);
         setRegister(dest, badgeRegister, badge);
         MCS_DO_IF_SC(dest, ntfnPtr, {

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -186,7 +186,6 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
 
     bool_t return_now = true;
     if (isSchedulable(sc->scTcb)) {
-        refill_unblock_check(sc);
         if (SMP_COND_STATEMENT(sc->scCore != getCurrentCPUIndex() ||)
             sc->scTcb->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority) {
             tcbSchedDequeue(sc->scTcb);


### PR DESCRIPTION
`refill_unblock_check` should be called when a thread is 'activated'.
This is the point where a thread becomes runnable (the literature
refers to this as the point where the currently executing priority level
is greater than or equal to the given thread's priority).

The function was being called when a thread was actually switched to but
this led to refills being delayed far more than necessary and meant that
periodic servers could not be implemented.

This should enable periodic servers to be implemented where they do not
block without ever donating their SC and use 'yield' signal the
completion of a task in a given period.